### PR TITLE
Fix entanglement func

### DIFF
--- a/src/structural_robustness/entanglement.py
+++ b/src/structural_robustness/entanglement.py
@@ -51,14 +51,9 @@ def entanglement(G: nx.Graph, mode: str = 'mid') -> Dict:
     ent = {}
     for node in pbar(G.nodes()):
         G_i = G.copy()
-        k = G_i.degree[node]
         G_i.remove_node(node)
 
         S_2 = entropy_func(G_i, beta)
-        G_star = nx.star_graph(k + 1)
-        S_star = compute_entropy(G_star, beta)
-
-        S_2 += S_star
         ent[node] = S_2 - S_1
 
     return ent


### PR DESCRIPTION
Removed the addition of unrelated star edges for S_2, as it does not align with the definition of entanglement. 
This issue led to incorrect LCC dismantling curves in example_usage.py.